### PR TITLE
WIP: Require email for idea submission

### DIFF
--- a/app/assets/stylesheets/ideas.css.sass
+++ b/app/assets/stylesheets/ideas.css.sass
@@ -137,3 +137,9 @@ button
 
 ul.similar
   padding-left: 25px
+
+#email-form
+  margin-bottom: 5px
+
+  input.email-address
+    width: 230px

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -103,7 +103,7 @@ class IdeasController < ApplicationController
     respond_with @results
   end
 
-  private
+private
 
   def idea_params
     params.require(:idea).permit(:title, :body, :subject, :tags, :citation_ids)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,7 @@ class UsersController < ApplicationController
 
   def update_email
     if current_user.update_attributes(user_params)
-      redirect_to(:back, :notice => "Email saved.")
+      redirect_to(new_idea_path, :notice => "Email saved.")
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   respond_to :json, :html
+
   def show
     @user = User.find_by_sha(params[:id])
     @ideas = @user.ideas.paginate(:page => params[:page], :per_page => 10)
@@ -9,5 +10,17 @@ class UsersController < ApplicationController
   def lookup
     @users = User.fuzzy_search(params[:query]).limit(10)
     respond_with @users.as_json(:methods => [ :nice_name, :sha ])
+  end
+
+  def update_email
+    if current_user.update_attributes(user_params)
+      redirect_to(:back, :notice => "Email saved.")
+    end
+  end
+
+private
+
+  def user_params
+    params.require(:user).permit(:email)
   end
 end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -75,11 +75,9 @@ class Idea < ActiveRecord::Base
 
   # Checks if the user has an email address on their record
   #
-  # Returns a boolean
+  # Returns nothing or false with some errors on [:base]
   def check_email
-    if self.user.email?
-      return true
-    else
+    unless self.user.email?
       errors[:base] << "You can't submit an idea without having a valid email associated with your account."
       return false
     end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -34,7 +34,7 @@ class Idea < ActiveRecord::Base
   has_many :idea_citations, :class_name => 'IdeaReference', :foreign_key => 'referenced_id'
   has_many :citations, :through => :idea_citations, :source => 'idea'
 
-  before_create :set_sha, :check_user_idea_count, :parse_references
+  before_create :set_sha, :check_user_idea_count, :parse_references, :check_email
   after_create :notify
 
   scope :today, lambda { where('created_at > ?', 1.day.ago) }
@@ -73,6 +73,22 @@ class Idea < ActiveRecord::Base
     end
   end
 
+  # Checks if the user has an email address on their record
+  #
+  # Returns a boolean
+  def check_email
+    if self.user.email?
+      return true
+    else
+      errors[:base] << "You can't submit an idea without having a valid email associated with your account."
+      return false
+    end
+  end
+
+  # Posts a tweet with the idea title, author name and link and updates the
+  # boolean 'tweeted' field
+  #
+  # Returns nothing
   def tweet!
     TWITTER.update("#{title} - #{user.nice_name}\n\nhttp://beta.briefideas.org/ideas/#{sha}")
     self.update_columns(:tweeted => true)

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -1,3 +1,5 @@
+<%= render 'layouts/errors', :object => @idea %>
+
 <%= form_for @idea, :html => {:data => {:toggle => "validator"}} do |f| %>
   <div class="form-group">
     <%= f.label :title, :class => "control-label" %>

--- a/app/views/ideas/new.html.erb
+++ b/app/views/ideas/new.html.erb
@@ -5,6 +5,7 @@
 <div class="row form">
   <div class="col-sm-8">
     <%= render :partial => 'shared/flashes', :locals => { :flash => flash } %>
+    <%= render :partial => "users/email" unless current_user.email? %>
     <%= render :partial => "form" %>
   </div>
   <div class="col-sm-3 col-sm-offset-1">

--- a/app/views/layouts/_errors.html.erb
+++ b/app/views/layouts/_errors.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert fade in alert-danger alert-dismissable"><button aria-hidden="true" class="close" data-dismiss="alert" type="button">×</button>
+    <ul>
+      <% object.errors.full_messages.each do |msg| %>
+        <%= content_tag :li, msg, :id => "error_#{msg}" if msg.is_a?(String) %>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/_email.html.erb
+++ b/app/views/users/_email.html.erb
@@ -1,0 +1,7 @@
+<%= form_tag("/users/update_email", :class => "form-inline bg-warning", :id => "email-form") do %>
+  <p>Please add an email address to your account before continuing. We'll use this to communicate the status of your idea. We promise not to spam you.</p>
+  <div class="form-group">
+    <%= email_field "user", "email", :placeholder => "your.email@example.com", :class => "form-control email-address" %>
+  </div>
+  <%= button_tag "Save", :class => "btn btn-default" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   end
 
   get '/user_lookup', to: "users#lookup", as: 'user_lookup'
+  post '/users/update_email', to: 'users#update_email'
   get '/idea_title_lookup', to: "ideas#lookup_title", as: 'idea_title_lookup'
 
   get '/admin/audits/:id', to: "admin#audits", as: 'admin_audits'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -24,7 +24,6 @@ describe UsersController, :type => :controller do
 
   describe "POST #update_email" do
     it "should update their email address" do
-      request.env["HTTP_REFERER"] = new_idea_path
       user = create(:no_email_user)
       allow(controller).to receive_message_chain(:current_user).and_return(user)
       params = {:email => "albert@gmail.com"}

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -21,4 +21,17 @@ describe UsersController, :type => :controller do
       assert_equal hash_from_json(response.body).count, 1
     end
   end
+
+  describe "POST #update_email" do
+    it "should update their email address" do
+      request.env["HTTP_REFERER"] = new_idea_path
+      user = create(:no_email_user)
+      allow(controller).to receive_message_chain(:current_user).and_return(user)
+      params = {:email => "albert@gmail.com"}
+
+      post :update_email, :user => params
+      expect(response).to be_redirect # as it's updated the email
+      expect(user.reload.email).to eq("albert@gmail.com")
+    end
+  end
 end

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -9,5 +9,9 @@ FactoryGirl.define do
     factory :admin_user do
       admin true
     end
+
+    factory :no_email_user do
+      email nil
+    end
   end
 end

--- a/spec/models/idea_spec.rb
+++ b/spec/models/idea_spec.rb
@@ -74,6 +74,13 @@ describe Idea do
     assert idea.voted_on_by?(user)
   end
 
+  it "should not be created if the owner doesn't have an email" do
+    user = create(:no_email_user)
+    idea = build(:idea, :user => user)
+    idea.save
+    expect(idea.errors[:base]).to eq(["You can't submit an idea without having a valid email associated with your account."])
+  end
+
   it "should know who its #creator is" do
     user = create(:user)
     idea = create(:idea, :user => user)

--- a/spec/views/ideas/new.html.erb_spec.rb
+++ b/spec/views/ideas/new.html.erb_spec.rb
@@ -14,5 +14,15 @@ describe 'ideas/new.html.erb' do
       expect(rendered).to have_selector('div.form-group', :count => 3)
       expect(rendered).to have_selector('div.references', :count => 0)
     end
+
+    it "for user without an email should prompt them to add one" do
+      user = create(:no_email_user)
+      allow(view).to receive(:current_user).and_return(user)
+      idea = Idea.new
+      assign(:idea, idea)
+
+      render :template => "ideas/new.html.erb"
+      expect(rendered).to match /Please add an email address to your account before continuing/
+    end
   end
 end


### PR DESCRIPTION
:construction: For notifications, (potential) multi-author submission and other features we really need to have an email address on file for the user.

Unfortunately ORCID doesn't give back email addresses with the `/authenticate` OAuth scope (the free one) and so we're going to have to ask people for it.