### PR TITLE
Adding basic support for Convergence conference

### DIFF
--- a/app/assets/stylesheets/general.css.sass
+++ b/app/assets/stylesheets/general.css.sass
@@ -89,3 +89,59 @@ button.tag-link
 .help-block
   h5, p
     color: $primary-color
+
+.bs-callout
+  padding: 20px
+  margin: 20px 0
+  border: 1px solid #eee
+  border-left-width: 5px
+  border-radius: 3px
+
+.bs-callout h4
+  margin-top: 0
+  margin-bottom: 5px
+
+.bs-callout p:last-child
+  margin-bottom: 0
+
+.bs-callout code
+  border-radius: 3px
+
+.bs-callout+.bs-callout
+  margin-top: -5px
+
+.bs-callout-default
+  border-left-color: #777
+
+.bs-callout-default h4
+  color: #777
+
+.bs-callout-primary
+  border-left-color: #428bca
+
+.bs-callout-primary h4
+  color: #428bca
+
+.bs-callout-success
+  border-left-color: #5cb85c
+
+.bs-callout-success h4
+  color: #5cb85c
+
+.bs-callout-danger
+  border-left-color: #d9534f
+
+.bs-callout-danger h4
+  color: #d9534f
+
+.bs-callout-warning
+  border-left-color: #f0ad4e
+
+.bs-callout-warning h4
+  color: #f0ad4e
+
+.bs-callout-info
+  border-left-color: #5bc0de
+
+.bs-callout-info h4
+  color: #5bc0de

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -64,6 +64,11 @@ class CollectionsController < ApplicationController
     end
   end
 
+  # Temporary hack for Convergence conference
+  def convergence
+
+  end
+  
 private
 
   def set_ideas

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -38,6 +38,13 @@ class IdeasController < ApplicationController
 
   def new
     @idea = Idea.new
+
+    if params[:tags]
+      @idea.tags = params[:tags].split(",").collect(&:strip)
+    end
+
+    # Are we automagically adding it to a collection on creation?
+    @collection = Collection.find_by_sha(params[:collection_id]) if params[:collection_id]
   end
 
   def create
@@ -46,9 +53,17 @@ class IdeasController < ApplicationController
     @idea.authors << current_user
 
     if @idea.save
+      associate_collection
       redirect_to idea_path(@idea), :notice => "Idea created"
     else
       render :action => "new"
+    end
+  end
+
+  # FIXME - you should only be able to do this for collections you own...
+  def associate_collection
+    if params["collection_id"] && collection = Collection.find_by_sha(params["collection_id"])
+      collection.ideas << @idea
     end
   end
 

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -60,10 +60,10 @@ class IdeasController < ApplicationController
     end
   end
 
-  # FIXME - you should only be able to do this for collections you own...
+  # Add this idea to a collection if it's open
   def associate_collection
     if params["collection_id"] && collection = Collection.find_by_sha(params["collection_id"])
-      collection.ideas << @idea
+      collection.ideas << @idea if collection.open?
     end
   end
 

--- a/app/views/collections/convergence.html.erb
+++ b/app/views/collections/convergence.html.erb
@@ -1,0 +1,43 @@
+<div class="page-header">
+  <h1>Convergence: What is the future of physics?</h1>
+</div>
+
+<div class="row form">
+  <div class="col-sm-8">
+    <%= render :partial => 'shared/flashes', :locals => { :flash => flash } %>
+
+    <p>We stand at a point where many experimental breakthroughs appear imminent, and theories are abundant. But which of these might be most likely, or at least plausible, and where does that lead us in the future?</p>
+
+    <p>Leading up to the Convergence conference at <%= link_to "Perimeter Institute for Theoretical Physics", "https://www.perimeterinstitute.ca", :target => "_blank" %>, we are soliciting brief ideas that capture the excitement of what might come to be.</p>
+
+    <p>Each submission is limited to 200 words, and should reflect a possible and plausible future result in any area of experimental or theoretical physics, or should be a comment on that proposed scenario with an elaboration of where that takes the field of physics next.</p>
+
+    <p>All ideas will be stored in the <%= link_to "Convergence collection of Brief Ideas", "http://beta.briefideas.org/collections/1cdfc8c9d59a2333b637efc67b6b9e8e" %> and you should review previously submitted ideas to get inspiration and to avoid duplication.</p>
+
+    <p><strong>Some tips on a good submission:</strong>
+      <ol>
+        <li>The title should be succinct and describe the outcome so that people can see at a glance what the progress in physics might be.</li>
+        <li>The idea shouldn't be so technical that physicists in other fields are unable to read it.</li>
+        <li>The idea doesn’t need to have all the details worked out (this is a forecast of the unknowable future, after all) but it should concrete and as specific as possible.</li>
+      </ol>
+    </p>
+
+    <p><strong>What to do now:</strong>
+      <ol>
+        <li>View the <%= link_to "previously submitted ideas", "http://beta.briefideas.org/collections/1cdfc8c9d59a2333b637efc67b6b9e8e" %></li>
+        <li><strong><%= link_to "Submit your own idea", new_idea_path(:tags => "convergence", :collection_id => "1cdfc8c9d59a2333b637efc67b6b9e8e") %></strong></li>
+        <li>Comment on somebody else's idea with the next possible step</li>
+      </ol>
+    </p>
+
+    <p>All ideas will be stored permanently and have a DOI assigned so that they can be cited just like regular papers and  can appear in your ORCID record.
+    </p>
+  </div>
+  <div class="col-sm-3 col-sm-offset-1">
+    <%= render :partial => 'sessions/login' %>
+
+    <div class="help-block">
+      <h5>Some help text</h5>
+    </div>
+  </div>
+</div>

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -25,6 +25,7 @@
     <div class="help-block with-errors"></div>
   </div>
 
+  <%= hidden_field_tag 'collection_id', @collection.sha if @collection %>
   <%= button_tag 'Save Idea', :data => { :confirm => "Once saved, you can edit and invite authors" }, :class => 'btn btn-default' %> <button class="btn btn-primary" id="preview-button" data-toggle="modal" data-target="#myModal">Preview</button>
 
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,9 @@ Rails.application.routes.draw do
   require 'sidekiq/web'
   mount Sidekiq::Web => '/sidekiq'
 
+  # Convergence
+  get '/convergence', to: "collections#convergence", as: "convergence"
+
   # Starburst
   mount Starburst::Engine => "/starburst"
 

--- a/db/migrate/20150608150345_add_open_flag_to_collections.rb
+++ b/db/migrate/20150608150345_add_open_flag_to_collections.rb
@@ -1,0 +1,5 @@
+class AddOpenFlagToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :open, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150605013914) do
+ActiveRecord::Schema.define(version: 20150608150345) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 20150605013914) do
     t.datetime "updated_at"
     t.string   "sha"
     t.text     "description"
+    t.boolean  "open",        default: false
   end
 
   add_index "collections", ["sha"], name: "index_collections_on_sha", using: :btree


### PR DESCRIPTION
Most of this is pretty unforgivable hacking at this point but basically this:

- Sets up a static route for `brief ideas.org/convergence` with some help text. 
- Makes it possible to pass a `collection_id` to the `ideas#new` which will automatically associate the idea with the collection (this is only possible if the collection is `open?`)
- Makes it possible to pass params `tags` when creating an idea to auto-populate this form field.