### PR TITLE
Removing requirement for login on convergence page

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,5 +1,5 @@
 class CollectionsController < ApplicationController
-  before_filter :require_user, :except => [ :show  ]
+  before_filter :require_user, :except => [ :show, :convergence  ]
 
   def new
     @collection = Collection.new
@@ -68,7 +68,7 @@ class CollectionsController < ApplicationController
   def convergence
 
   end
-  
+
 private
 
   def set_ideas


### PR DESCRIPTION
Partially fixes https://github.com/openjournals/brief-ideas/issues/126 (insofar there shouldn't be a login requirement for this view)