### PR TITLE
Email authors on submission too

### DIFF
--- a/app/mailers/notification.rb
+++ b/app/mailers/notification.rb
@@ -11,6 +11,12 @@ class Notification < ActionMailer::Base
     mail(:to => EDITOR_EMAILS, :subject => "New submission: #{idea.title}")
   end
 
+  def author_submission_email(idea)
+    @url  = "http://beta.briefideas.org/ideas/#{idea.sha}"
+    @idea = idea
+    mail(:to => idea.submitting_author.email, :subject => "Idea submitted: #{idea.title}")
+  end
+
   def ratings_email
     mail(:to => SYSTEM_EMAILS, :subject => "Ratings updated")
   end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -14,6 +14,7 @@ class Idea < ActiveRecord::Base
     event :submit do
       after do
         notify_editor
+        notify_author
       end
 
       transitions :to => :submitted
@@ -203,6 +204,10 @@ class Idea < ActiveRecord::Base
 
   def notify_editor
     Notification.submission_email(self).deliver
+  end
+
+  def notify_author
+    Notification.author_submission_email(self).deliver
   end
 
   def parent?

--- a/app/views/notification/author_submission_email.text.erb
+++ b/app/views/notification/author_submission_email.text.erb
@@ -1,0 +1,7 @@
+Hi, <%= @idea.submitting_author.nice_name %>.
+
+We've received your idea <%= @idea.title %> and will be reviewing it shortly. You can keep track of the staus of your idea here: <%= @url %>
+
+Please note, you will receive an additional email with your acceptance decision.
+
+Yours, the Journal of Brief Ideas robot.

--- a/spec/models/idea_spec.rb
+++ b/spec/models/idea_spec.rb
@@ -33,11 +33,11 @@ describe Idea do
     expect(RatingWorker.jobs.size).to eq(0)
   end
 
-  it "should email the editor when submitted" do
+  it "should email the editor and author when submitted" do
     idea = create(:idea)
     idea.authors << create(:user)
 
-    expect {idea.submit!}.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect {idea.submit!}.to change { ActionMailer::Base.deliveries.count }.by(2)
   end
 
   it "should queue ZenodoWorker when published" do


### PR DESCRIPTION
Currently authors don't get a submission email when they submit. This fixes that.

Fixes #143 
Fixes #133